### PR TITLE
Fix uncaught TypeError on fetch network failures

### DIFF
--- a/src/service/FlickrAPI.ts
+++ b/src/service/FlickrAPI.ts
@@ -5,17 +5,25 @@ interface photosetProps {
 }
 export const getPhotosets = async () => {
   const getPhotosetsUrl = `https://api.flickr.com/services/rest/?method=flickr.photosets.getList&api_key=${import.meta.env.VITE_FLICKR_API_KEY}&user_id=${FLICKR_USER_ID}&format=json&nojsoncallback=true`;
-  const response = await fetch(getPhotosetsUrl);
-  return response && response.ok
-    ? (await response.json()).photosets.photoset.map((p: photosetProps) => p.id)
-    : 'Error while fetching user\'s photosets';
+  try {
+    const response = await fetch(getPhotosetsUrl);
+    return response.ok
+      ? (await response.json()).photosets.photoset.map((p: photosetProps) => p.id)
+      : 'Error while fetching user\'s photosets';
+  } catch {
+    return 'Error while fetching user\'s photosets';
+  }
 };
 
 export const getPhotos = async (photoSetId: string, sizes: string[]) => {
   const sizesParam = sizes.join(',');
   const getPhotosUrl = `https://api.flickr.com/services/rest/?method=flickr.photosets.getPhotos&api_key=${import.meta.env.VITE_FLICKR_API_KEY}&photoset_id=${photoSetId}&extras=${sizesParam}&format=json&nojsoncallback=true`;
-  const response = await fetch(getPhotosUrl);
-  return response && response.ok
-    ? (await response.json()).photoset.photo
-    : `Error while reading photoset=${photoSetId}`;
+  try {
+    const response = await fetch(getPhotosUrl);
+    return response.ok
+      ? (await response.json()).photoset.photo
+      : `Error while reading photoset=${photoSetId}`;
+  } catch {
+    return `Error while reading photoset=${photoSetId}`;
+  }
 };

--- a/src/service/GIPHYApi.ts
+++ b/src/service/GIPHYApi.ts
@@ -16,15 +16,23 @@ export interface GiphyResult {
 }
 
 export const getAnimations = async ():Promise<GiphyResult[] | string> => {
-  const response = await fetch(animationsSearchUrl);
-  return response && response.ok
-    ? (await response.json()).data
-    : 'Error while fetching user\'s giphy';
+  try {
+    const response = await fetch(animationsSearchUrl);
+    return response.ok
+      ? (await response.json()).data
+      : 'Error while fetching user\'s giphy';
+  } catch {
+    return 'Error while fetching user\'s giphy';
+  }
 };
 
 export const getStickers = async () => {
-  const response = await fetch(stickersSearchUrl);
-  return response && response.ok
-    ? (await response.json()).data
-    : 'Error while fetching user\'s giphy';
+  try {
+    const response = await fetch(stickersSearchUrl);
+    return response.ok
+      ? (await response.json()).data
+      : 'Error while fetching user\'s giphy';
+  } catch {
+    return 'Error while fetching user\'s giphy';
+  }
 };


### PR DESCRIPTION
## Summary
- `fetch()` calls in `FlickrAPI.ts` and `GIPHYApi.ts` handled non-ok HTTP responses but not network-level errors (offline, CORS, DNS failures)
- When `fetch()` throws, the error bubbled up uncaught as `TypeError: Load failed` through the hooks to Datadog RUM
- Wrapped each `fetch()` call in try-catch, returning the same error string callers already handle so existing failure state logic works correctly

https://app.datadoghq.eu/error-tracking/issue/95124cd0-4e27-11f1-a40b-da7ad0900005

## Test plan
- [ ] Verify illustrations/animations screens show error state (not crash) when network is unavailable
- [ ] Confirm no `TypeError: Load failed` errors surface in RUM after deploy